### PR TITLE
Remove random from reducers and move them in action creators

### DIFF
--- a/src/scripts/actions/actions.js
+++ b/src/scripts/actions/actions.js
@@ -1,12 +1,17 @@
 import actionTypes from "./actionTypes";
+import {randomCell} from "js/helpers";
+import {STARTING_TILES} from "js/constants";
+import {newTile as newTileReducer} from "js/reducers/Game";
 
 /**
  * Create a new random tile.
  */
 export function newTile() {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const state = getState().game;
     dispatch({
-      type: actionTypes.NEW_TILE
+      type: actionTypes.NEW_TILE,
+      cell: randomCell(state.get("cells"))
     });
   };
 }
@@ -51,9 +56,15 @@ export function mergeTiles() {
  * Initialize a new game.
  */
 export function initGame() {
-  return dispatch => {
+  return (dispatch, getState) => {
+    let state = getState().game;
     dispatch({
-      type: actionTypes.INIT_GAME
+      type: actionTypes.INIT_GAME,
+      cells: _.times(STARTING_TILES, () => {
+        const cell = randomCell(state.get("cells"));
+        state = newTileReducer(state, cell);
+        return cell;
+      })
     });
   };
 }

--- a/src/scripts/reducers/Game.js
+++ b/src/scripts/reducers/Game.js
@@ -8,13 +8,11 @@ import {getCurrent} from "js/utils/vectors";
 import {
   generateCells,
   generateGrid,
-  forEachCell,
-  randomCell
+  forEachCell
 } from "js/helpers";
 
 import {
   INITIAL,
-  STARTING_TILES,
   DIRECTIONS,
   SIZE,
   WIN_SCORE, START_SCORE
@@ -87,10 +85,9 @@ function addTile(state, tile, value) {
  * @param {Object} state
  * @returns {Object}
  */
-function newTile(state) {
+export function newTile(state, cell) {
   if (!state.get("cells").size) return state;
 
-  const cell = randomCell(state.get("cells"));
   const tile = state.getIn(["cells", cell]);
   const x = state.get("grid").flatten(2).find(t => t.get("value") === "x");
 
@@ -312,7 +309,7 @@ function mergeTiles(state) {
 export default (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.NEW_TILE:
-      return newTile(state);
+      return newTile(state, action.cell);
 
     case actionTypes.MOVE_TILES:
       return moveInDirection(state, action.direction);
@@ -326,7 +323,7 @@ export default (state = initialState, action) => {
     case actionTypes.INIT_GAME:
       store(false);
       state = defaultState;
-      _.times(STARTING_TILES, () => state = newTile(state));
+      action.cells.map(cell => state = newTile(state, cell));
       return state;
 
     case actionTypes.GAME_OVER:


### PR DESCRIPTION
Hi, great job with this repo. To be honest I wanted to reuse your project to illustrate Redux Dev Tools usage.

Unfortunately, the fact that the random calculation happened inside the reducers made this messy when playing with dev tools because when you remove and restore an action, the random values changed.

So, I tried moving the randoms in the action creators. It seems to work, what do you think of this?
